### PR TITLE
Add sevenths

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,5 @@ python chords.py
 python intervals.py
 ```
 Can optionally specify an argument, either "learn" or "quiz" to specify the mode. If none specified, defaults to "quiz".
+
+Additionally, the `-s` flag can be passed to chords.py in order to study seventh chords instead of the usual triads.

--- a/chords.py
+++ b/chords.py
@@ -15,12 +15,11 @@ TRIAD_FUNCS = [chords.major_triad, chords.minor_triad, chords.diminished_triad, 
 SEVENTH_CHORD_NAMES = ['major', 'minor', 'diminished', 'minor-major', 'dominant', 'dominant flat-five (french augmented sixth)', 'augmented']
 SEVENTH_CHORD_FUNCS = [chords.major_seventh, chords.minor_seventh, chords.diminished_seventh, chords.minor_major_seventh, chords.dominant_seventh, chords.dominant_flat_five, chords.augmented_minor_seventh]
 
-def get_bar_from_chord(chord, size=3):
-	assert len(chord) == size
+def get_bar_from_chord(chord):
 	chord = make_ascending(chord)
 	# print chord
 
-	b = Bar()
+	b = Bar(meter=(len(chord) + 1, 4))
 	for n in chord:
 		b.place_notes(n, 4)  ## add quarter note
 	b.place_notes(chord, 4)
@@ -42,7 +41,7 @@ if __name__ == '__main__':
 		fs.play_Bar(get_bar_from_chord(TRIAD_FUNCS[choice](key)))
 
 	def play_seventh_chord(choice, key):
-		fs.play_Bar(get_bar_from_chord(SEVENTH_CHORD_FUNCS[choice](key), 4))
+		fs.play_Bar(get_bar_from_chord(SEVENTH_CHORD_FUNCS[choice](key)))
 
 	if SEVENTH_CHORD_FLAG in sys.argv:
 		chord_names = SEVENTH_CHORD_NAMES

--- a/chords.py
+++ b/chords.py
@@ -7,40 +7,59 @@ import mingus.core.chords as chords
 
 from utils import learn, quiz, make_ascending
 
+SEVENTH_CHORD_FLAG = '-s'
 
-CHORD_NAMES = ['major', 'minor', 'diminished', 'augmented', 'suspended']
-CHORD_FUNCS = [chords.major_triad, chords.minor_triad, chords.diminished_triad, chords.augmented_triad, chords.suspended_fourth_triad]
+TRIAD_NAMES = ['major', 'minor', 'diminished', 'augmented', 'suspended']
+TRIAD_FUNCS = [chords.major_triad, chords.minor_triad, chords.diminished_triad, chords.augmented_triad, chords.suspended_fourth_triad]
 
-def get_bar_from_triad(triad):
-	assert len(triad) == 3
-	triad = make_ascending(triad)
-	# print triad
+SEVENTH_CHORD_NAMES = ['major', 'minor', 'diminished', 'minor-major', 'dominant', 'dominant flat-five (french augmented sixth)', 'augmented']
+SEVENTH_CHORD_FUNCS = [chords.major_seventh, chords.minor_seventh, chords.diminished_seventh, chords.minor_major_seventh, chords.dominant_seventh, chords.dominant_flat_five, chords.augmented_minor_seventh]
+
+def get_bar_from_chord(chord, size=3):
+	assert len(chord) == size
+	chord = make_ascending(chord)
+	# print chord
 
 	b = Bar()
-	for n in triad:
+	for n in chord:
 		b.place_notes(n, 4)  ## add quarter note
-	b.place_notes(triad, 4)
+	b.place_notes(chord, 4)
 	return b
 
-def learn_chords(play_func):
-	learn(CHORD_NAMES, play_func)
+def learn_chords(chord_names, play_func):
+	learn(chord_names, play_func)
 
-def quiz_chords(play_func):
-	quiz(CHORD_NAMES, play_func)
+def quiz_chords(chord_names, play_func):
+	quiz(chord_names, play_func)
 
+def usage():
+	print "Usage: python chords.py [-s] [learn|quiz]"
 
 if __name__ == '__main__':
 	fs.init('GeneralUser GS 1.471/GeneralUser GS v1.471.sf2')
 
-	def play_chord(choice, key):
-		fs.play_Bar(get_bar_from_triad(CHORD_FUNCS[choice](key)))
+	def play_triad(choice, key):
+		fs.play_Bar(get_bar_from_chord(TRIAD_FUNCS[choice](key)))
 
-	if len(sys.argv) > 1:
-		if sys.argv[1] == 'learn':
-			learn_chords(play_chord)
-		elif sys.argv[1] == 'quiz':
-			quiz_chords(play_chord)
-		else:
-			print "First arg should be 'learn' or 'quiz'."
+	def play_seventh_chord(choice, key):
+		fs.play_Bar(get_bar_from_chord(SEVENTH_CHORD_FUNCS[choice](key), 4))
+
+	if SEVENTH_CHORD_FLAG in sys.argv:
+		chord_names = SEVENTH_CHORD_NAMES
+		play_func = play_seventh_chord
+		sys.argv.remove(SEVENTH_CHORD_FLAG)
 	else:
-		quiz_chords(play_chord)
+		chord_names = TRIAD_NAMES
+		play_func = play_triad
+
+	if len(sys.argv) <= 1:
+		quiz_chords(chord_names, play_func)
+	elif len(sys.argv) == 2:
+		if sys.argv[1] == 'learn':
+			learn_chords(chord_names, play_func)
+		elif sys.argv[1] == 'quiz':
+			quiz_chords(chord_names, play_func)
+		else:
+			usage()
+	else:
+		usage()

--- a/intervals.py
+++ b/intervals.py
@@ -8,8 +8,8 @@ import mingus.core.intervals as intervals
 from utils import learn, quiz, make_ascending
 
 
-INTERVAL_NAMES = ['major third', 'minor third', 'major fifth']
-INTERVAL_FUNCS = [intervals.major_third, intervals.minor_third, intervals.major_fifth]
+INTERVAL_NAMES = ['major third', 'minor third', 'major fifth', 'major seventh', 'minor seventh']
+INTERVAL_FUNCS = [intervals.major_third, intervals.minor_third, intervals.major_fifth, intervals.major_seventh, intervals.minor_seventh]
 
 def get_bar_from_interval(interval):
 	assert len(interval) == 2

--- a/utils.py
+++ b/utils.py
@@ -37,7 +37,7 @@ def quiz(option_names, play_func):
 		else:
 			print 'Whoops, ' + option_names[choice]
 
-ANSWER_INPUTS = ['p', '[', ']', ';', '\'']
+ANSWER_INPUTS = ['p', '[', ']', ';', '\'', '.', '/']
 def _get_intput_to_choice(num_answers):
 	lookup = {v:k for k,v in enumerate(ANSWER_INPUTS[:num_answers])}
 	def _input_to_choice(answer_input):


### PR DESCRIPTION
• Add major and minor sevenths to `intervals.py`
• Add a new flag `-s` to `chords.py` that, when specified, causes seventh chords to be used instead of triads
• In order to support all of those seventh chords, two new response options are added: `.` and `/`
• Tweak the CLI interface to print out a brief usage summary when invalid flags or commands are specified